### PR TITLE
Fix #9 same router path for diffrent components

### DIFF
--- a/src/options/app.vue
+++ b/src/options/app.vue
@@ -1,4 +1,10 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import {useRouter} from 'vue-router';
+
+const router = useRouter()
+router.push({path: 'options'})
+
+</script>
 
 <template>
   <RouterView></RouterView>

--- a/src/popup/app.vue
+++ b/src/popup/app.vue
@@ -1,4 +1,10 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+
+const router = useRouter()
+router.push({ path: 'popup' })
+
+</script>
 
 <template>
   <RouterView></RouterView>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,11 +24,11 @@ export default defineConfig({
       dirs: [
         {
           dir: 'src/options/pages',
-          baseRoute: '',
+          baseRoute: 'options',
         },
         {
           dir: 'src/popup/pages',
-          baseRoute: '',
+          baseRoute: 'popup',
         },
       ],
     }),


### PR DESCRIPTION
This fixs issue #9 

- Add base path for each components.
- Add router push code for each componets. 

so that, when open each [options, popup] index.html, it shows own router path component.