### PR TITLE
fix(ci): `set-output` command is deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,15 @@ jobs:
 
       - name: Get Package Version
         id: get-version
-        run: echo "::set-output name=version::$(node -p "require('./package.json').version")"
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
 
       - run: npm run build
-      - run: zip -r ${{ steps.get-version.outputs.version }}.zip dist
+      - run: zip -r ${{ env.version }}.zip dist
 
       - name: GH Release
         uses: softprops/action-gh-release@v0.1.15
         with:
-          tag_name: ${{ steps.get-version.outputs.version }}
-          release_name: ${{ steps.get-version.outputs.version }}
+          tag_name: ${{ env.version }}
+          name: ${{ env.version }}
           draft: true
-          files: ${{ steps.get-version.outputs.version }}.zip
+          files: ${{ env.version }}.zip


### PR DESCRIPTION
1. The `set-output` command is deprecated and will be disabled soon. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
2. `softprops/action-gh-release` doesn't have `release_name` in README. I think should use `name`