### PR TITLE
fix: page base route

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       dirs: [
         {
           dir: 'src/pages',
-          baseRoute: '',
+          baseRoute: 'common',
         },
         {
           dir: 'src/setup/pages',

--- a/vite.firefox.config.ts
+++ b/vite.firefox.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       dirs: [
         {
           dir: 'src/pages',
-          baseRoute: '',
+          baseRoute: 'common',
         },
         {
           dir: 'src/setup/pages',


### PR DESCRIPTION
fix the issue when loaded in Chrome:

```
[Vue Router warn]: No match found for location with path "/common/about"

Context
src/popup/index.html#/popup
```