### PR TITLE
fix: replace backslashes in paths for Firefox compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,10 +89,8 @@ export default defineConfig({
       enforce: 'post',
       apply: 'build',
       transformIndexHtml(html, { path }) {
-        return html.replace(
-          /"\/assets\//g,
-          `"${relative(dirname(path), '/assets')}/`
-        )
+        const assetsPath = relative(dirname(path), '/assets').replace(/\\/g, '/');
+        return html.replace(/"\/assets\//g, `"${assetsPath}/`);
       },
     },
   ],


### PR DESCRIPTION
Fix URI path issue in Firefox by replacing backslashes with forward slashes in build output